### PR TITLE
wip: enrollment specification

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@ The spec is divided per-component:
  - [Server](server.md): (WIP) Server policy specification.
  - [Manifest](manifest.md): (WIP) Web application manifest specification.
  - [CSP](csp.md): (WIP) Allowed and required CSP directives within manifests.
- - [Enrollment](enrollment.md): (TODO) Enrollment and WEBCAT list management specification for the WEBCAT infrastructure.
+ - [Enrollment](enrollment.md): Enrollment and WEBCAT snapshot specification for the WEBCAT infrastructure.
  - [Client](client.md): (TODO) Client update, server and manifest validation specification.
 
 See also:

--- a/enrollment.md
+++ b/enrollment.md
@@ -1,0 +1,153 @@
+# WEBCAT Enrollment Specification
+
+This document explains how domains enroll into WEBCAT and how validators and oracles validate enrollment requests.
+
+The enrollment data would be processed and stored in a permissioned CometBFT chain, where the voting network consists of trusted partner orgs (other nonprofits, Tor relay associations, browsers) acting as validators in the CometBFT consensus. Any third party can operate an observer node that allows them to check consistency, behavior, or monitor entries and updates.
+
+# Background
+
+CometBFT is a Byzantine Fault Tolerant (BFT) consensus algorithm derived from [Tendermint](https://arxiv.org/abs/1807.04938). It provides a round-based protocol that will reach consensus as long as at least $\gt 2/3$ of the validator voting power is online and honest. The benefit of using CometBFT is that consensus and the networking parts of the chain are handled by an external dependency.
+
+The blockchain state machine runs as an ABCI application. The consensus algorithm orders transactions into blocks, and the ABCI application executes them into the application state.
+
+The ABCI interface consists of:
+- `CheckTx`: basic validity checks run on transactions prior to them being added to the mempool
+- `DeliverTx`: validity checks that run when the transaction is included in a block
+- `BeginBlock`/`EndBlock`: hooks to run logic that runs at the beginning and end of a block boundary respectively
+- `Commit`: finalizes the application state for that block
+
+After executing all transactions in a block, the Merkleized application state root, the AppHash, is committed into the block header and signed by validators. This will be used by WEBCAT as a verifiable timestamped commitment.
+
+## Timestamp
+
+The CometBFT AppHash is a timestamped commitment, so it can serve as the timestamp to ensure that manifests cannot be signed with future dates.
+
+Each block produced by the enrollment network has a block height (a monatonic counter enforced by consensus), the corresponding AppHash, and a consensus timestamp. By signing a manifest that includes `(AppHash, height, timestamp)`, the manifest signer demonstrates that the manifest could not have existed before that block was finalized.
+
+Previous proofs (older AppHash values) can be reused in manifests, allowing for backdating. This is acceptable because the security goal is to prevent future-dating, wherein a manifest would be valid longer than it should be.
+
+The chain itself does not enforce expiry, clients check the expiry using the consensus timestamp.
+
+The consensus data will be published to a CDN with the following structure:
+
+```json
+{
+  "height": 12345,
+  "app_hash": "abc123def456...",
+  "timestamp": 1640995200,
+  "block_time": "2025-05-01T00:00:00Z"
+}
+```
+
+This allows clients to verify the `AppHash` against the chain and check manifest expiry using the consensus timestamp.
+
+## Enrollment
+
+Chain parameters:
+- `MAX_NUMBER_SUBDOMAINS`: the maximum number of subdomains per domain to rate limit abuse.
+- `NUM_REQUIRED_ORACLES`: the number of oracle observations that must post a response to the chain
+- `COOLDOWN_BLOCKS`: the number of blocks that must elapse before the domain is allowed to move from the pending set to the active set.
+- `TIMEOUT_BLOCKS`: if insufficient oracle observations arrive within this number of blocks, the enrollment request expires.
+
+### `EnrollmentRequest`
+
+Invariants:
+- Non-concurrent: There cannot be multiple enrollment requests for a domain.
+
+The enrollment process involves:
+1. User places `enrollment.json` at:
+
+```
+https://<domain>/.well-known/webcat/enrollment.json
+```
+
+2. User submits an `EnrollmentRequest` to the chain.
+3. Transaction validation (`CheckTx`/`DeliverTx`)
+
+To unenroll, clients must remove the enrollment JSON and oracles verify that path produces a 404 or 410.
+
+#### Structure
+
+An `EnrollmentRequest` contains (TODO):
+- domain:
+- subdomains:
+- `signers`: a list of Ed25519 public keys
+
+#### `CheckTx`/`DeliverTx`
+
+We validate:
+- The maximum number of subdomains per domain has not been reached.
+
+The pending set tracks domains awaiting oracle observations. Each entry contains:
+
+- `domain`: the domain name
+- `request_height`: the block height when the request was submitted
+- `enrollment_data`: the signing data from the enrollment request
+- `oracle_observations`: oracle responses received so far (TODO do we need this?)
+
+Upon a new validated enrollment request:
+- If no pending request exists for the domain, we add it to the pending set.
+- If a pending request already exists for that domain, we remove the existing pending entry, add a new entry with the current block height as `request_height` with `oracle_observations` set to empty.
+
+Note that a domain can be in the active set and there can be an update in the pending set.
+
+#### `EndBlock`
+
+We iterate through all new oracle observations in the block and:
+- Add the observation to the appropriate entry in the pending set.
+
+We iterate through all domains in the pending set and verify:
+- At least `NUM_REQUIRED_ORACLES` matching observations have been submitted, i.e. all responses agree on the `response_hash` provided in the oracle observation
+- `COOLDOWN_BLOCKS` have elapsed since the request height
+- `TIMEOUT_BLOCKS` has not yet elapsed
+
+If both checks pass, we promote the domain from the pending to active set, i.e. removing from the pending set, and adding to the active set.
+
+### `OracleObservation`
+
+For each new domain in the pending set, oracles:
+
+1. Fetch:
+
+```
+https://<domain>/.well-known/webcat/enrollment.json
+```
+
+2. Validate:
+- The HTTPS certificate is valid (hostname matches, chain trusted, not expired/revoked).
+- The response is either:
+    - A correctly formatted policy JSON
+    - A 404 or 410 (Gone) for unenrollment
+
+3. Returns:
+- Hash of the file (or a marker for 404/410)
+- Success/Failure
+
+4. Post observation to the chain.
+
+#### Structure
+
+The `OracleObservation` should contain:
+- `domain`: the domain being observed
+- `request_height`: block height of the original enrollment request
+- `observation_height`: block height when this observation was made
+- `http_status_code`: code returned on fetch, e.g. 200, 404, 410
+- `response_hash`: SHA256 hash of the enrollment.json file, or Null if 404/410 or error occurs
+- `oracle_id`: public key of the oracle making this observation
+- `signature`: Ed25519 signature of the observation data
+
+## Snapshot
+
+The snapshot is:
+- a serialization of the enrollment subtree of the application state
+- a merkle proof to the AppHash
+
+TODO: Include back of the envelope numbers
+
+The snapshot is deterministic: by using the state at a particular block height, all full nodes will produce identical snapshots.
+
+The snapshot enables users to verify inclusion of a domain using only the snapshot and Merkle proof.
+
+Operationally, we'll scrape the state from a node and push it to a CDN. This can be done through a serverless cron job.
+
+Optionally, we could compute and publish incremental diffs relative to previous snapshots to reduce bandwidth usage.

--- a/server.md
+++ b/server.md
@@ -1,14 +1,15 @@
 ## Server configuration
-To participate in the WEBCAT integrity verification system, a website MUST advertise a cryptographic enrollment policy via a custom HTTP response header. This policy defines the set of trusted signers, the signature threshold, and the Sigsum-based policy used to validate the transparency logging signed manifest updates.
+To participate in the WEBCAT integrity verification system, a website MUST advertise a cryptographic enrollment policy via a well-known path. This policy defines the set of trusted signers, the signature threshold, and the Sigsum-based policy used to validate the transparency logging signed manifest updates.
 
-### 1. `x-webcat` Header
+### 1. Well-Known Enrollment Path
 
-Websites MUST include the `x-webcat` header in all HTTP responses, including:
+Websites MUST serve their enrollment policy at:
 
-- `/index.html` or `/` (used for enrollment discovery)
-- All subresources (scripts, workers, etc.)
+```
+https://<domain>/.well-known/webcat/enrollment.json
+```
 
-The value of this header MUST be a JSON object with the following structure:
+This endpoint MUST return a JSON object with the following structure:
 
 ```json
 {
@@ -17,26 +18,25 @@ The value of this header MUST be a JSON object with the following structure:
   "policy": {
     // See "Sigsum Policy Format"
   },
+  "max_age": <integer>
 }
 ```
 
-_TODO_: Clients check this upon first visit, and then cache the policy. Serving it in all HTTP requests adds significant overhead, and is likely avoidable. We should have a speciifc validation path for enrollment, and then possibly attach this metadata to manifest files, which have to be fetched anyway.
+The enrollment policy is discovered by clients during the enrollment process and cached for the duration of the domain's enrollment. This approach eliminates the overhead of including policy data in every HTTP response.
 
 #### 1.1 Field Definitions
 
-- `signers`:  
+- `signers`:
   An array of Ed25519 public keys, base64-encoded. These keys are authorized to sign WebCAT manifest files for the domain.
 
-- `threshold`:  
+- `threshold`:
   An integer ≥ 1 indicating the minimum number of distinct valid signatures required to accept a manifest as valid. The value of `threshold` MUST be less than or equal to the number of entries in `signers`.
 
-- `policy`:  
+- `policy`:
   A JSON object specifying the transparency log configuration and the associated witness policy required to validate signed checkpoints. This includes the list of witnesses, group definitions, and quorum requirements. See [Sigsum Policy Format](#sigsum-policy-format) for details.
 
-- `max_age`:  
-  An integer representing the maximum number of seconds a manifest may remain valid after its signing timestamp. Since different signatures might have different inclusion times, `max_age` is always counted from the oldest one. _TODO: what do we check this against? We could use the infra chain as a distributed timestamping authority, and requiring the inclusion of a timestamped consensus as proof of time. As we'd have a library to verify consensus anyways for the preload list updates, it should be easy to implement._
-
-
+- `max_age`:
+  An integer representing the maximum number of seconds a manifest may remain valid after its signing timestamp. Since different signatures might have different inclusion times, `max_age` is always counted from the oldest one. The timestamp is verified against the CometBFT chain's AppHash as described in the enrollment specification.
 
 ### 2. Policy Transition Mechanism
 
@@ -46,19 +46,19 @@ To transition from one enrollment policy to another, servers MUST follow a stric
 
 When initiating a policy change:
 
-- The new policy MUST be served persistently in the `x-webcat` header.
-- The previous policy SHOULD be served in the `x-webcat-prev` header.
-- The values of `x-webcat` and `x-webcat-prev` MUST differ.
+- The new policy MUST be served persistently at `/.well-known/webcat/enrollment.json`.
+- The previous policy SHOULD be served at `/.well-known/webcat/enrollment-prev.json`.
+- The values of the two files MUST differ.
 
 #### 2.2 Enrollment Observation Period
 
-Once the new policy is published, it enters a transition period during which enrollment systems monitor the header for consistency and stability.
+Once the new policy is published, it enters a transition period during which enrollment systems monitor the well-known path for consistency and stability.
 
 > ⚠️ **During this period, no clients have switched to the new policy yet.**
 
 To prevent enrollment failure:
-- The contents of `x-webcat` MUST remain unchanged throughout this period.
-- Any modification to `x-webcat` before the transition completes will invalidate the attempt.
+- The contents of `/.well-known/webcat/enrollment.json` MUST remain unchanged throughout this period.
+- Any modification to the enrollment file before the transition completes will invalidate the attempt.
 
 _TODO: since anybody can submit a request for enrollment or de-enrollment, so can do the infra chain itself. This allows for periodic list clenaups not to clog browsers, to remove expired or abandone domains. It can also backfire in some ways though. We should probably always send an alert to the whois email when a change is initiated._
 
@@ -70,27 +70,36 @@ After the transition is accepted:
 - Eventually, all clients will converge on the new state.
 
 To ensure full compatibility throughout this staggered rollout:
-- The server SHOULD continue serving `x-webcat-prev` until all clients are expected to have adopted the new policy.
-- Once adoption is widespread, `x-webcat-prev` SHOULD be removed.
+- The server SHOULD continue serving `/.well-known/webcat/enrollment-prev.json` until all clients are expected to have adopted the new policy.
+- Once adoption is widespread, `/.well-known/webcat/enrollment-prev.json` SHOULD be removed.
 
 #### 2.4 Example
 
-```http
-x-webcat: { "signers": [...], "threshold": 2, ... }
-x-webcat-prev: { "signers": [...], "threshold": 3, ... }
+```json
+// /.well-known/webcat/enrollment.json
+{ "signers": [...], "threshold": 2, ... }
+
+// /.well-known/webcat/enrollment-prev.json
+{ "signers": [...], "threshold": 3, ... }
 ```
 
 In this example, the server is advertising a new policy requiring 2 signers, while still supporting the older 3-signer policy during the transition window.
 
 ### 3. Policy Delegation (Optional)
 
-Websites MAY include an additional header to aid user understanding by referencing another domain’s policy:
+Websites MAY include a delegation field in their enrollment.json to aid user understanding by referencing another domain's policy:
 
-```
-x-webcat-delegation: <delegated-fqdn>
+```json
+{
+  "signers": [...],
+  "threshold": 2,
+  "policy": {...},
+  "max_age": 86400,
+  "delegation": "cryptpad.org"
+}
 ```
 
-This header is not security critical, and thus its integrity does not need guarantees. This header signals to the browsers that the policy of this websites should match the policy of another domain. A practical example could be: cryptpad.org developes and host a flasgship instance of CryptPad. As the CryptPad developers are expected to define the policy for their product and sign accordingly to it, websites who do not fork and change the would want to enforce the same policy. Thus, the policy of cryptpad.collective.it could be the same of cryptpad.org. the `w-webcat-delegation` header provides this information to the browser, and confirm it by performing a local lookup in the preload list. If the header matches, the browser SHOULD expose this information to the end user in a format TBD based on UX considerations. A basic example could be "Verified by cryptpad.org").
+This field is not security critical, and thus its integrity does not need guarantees. This field signals to browsers that the policy of this website should match the policy of another domain. A practical example could be: cryptpad.org develops and hosts a flagship instance of CryptPad. As the CryptPad developers are expected to define the policy for their product and sign accordingly to it, websites who do not fork and change the code would want to enforce the same policy. Thus, the policy of cryptpad.collective.it could be the same as cryptpad.org. The `delegation` field provides this information to the browser, and confirms it by performing a local lookup in the preload list. If the delegation matches, the browser SHOULD expose this information to the end user in a format TBD based on UX considerations. A basic example could be "Verified by cryptpad.org").
 
 ### 4. Sigsum Policy Format
 


### PR DESCRIPTION
This adds a description of how the enrollment chain could operate. There's a few TODOs inline but putting this draft up to make it easier to comment on.

I also updated the server spec to reflect that the enrollment JSON will be provided at a specific path and not via the `x-webcat` header. Comments welcome!