### PR TITLE
Update spec to support sigstore and sigsum

### DIFF
--- a/server.md
+++ b/server.md
@@ -9,7 +9,7 @@ Websites MUST serve their enrollment policy at:
 https://<domain>/.well-known/webcat/enrollment.json
 ```
 
-The enrollment policy is discovered asynchronously by clients during the first HTTP request and cached for the duration of the browser' session. This approach eliminates the overhead of including policy data in every HTTP response. However, websites have menchanisms to signal that the information MUST be refreshed.
+The enrollment policy is discovered asynchronously by clients during the first HTTP request and cached for the duration of the browser session. This approach eliminates the overhead of including policy data in every HTTP response. However, websites have mechanisms to signal that the information MUST be refreshed.
 
 
 #### 1.1 Field Definitions (Sigsum)


### PR DESCRIPTION
Updates the spec to address the changes in https://github.com/freedomofpress/webcat/pull/93 and https://github.com/freedomofpress/webcat-cli/pull/2.

Goal is to define a format to support both Sigstore and Sigsum. Format is not stable yet, though the goal would be to add but not change existing fields. In particular, we'll likely end up adding fields (or changing the identity/issuer) to support sigstore custom claims (about identity or provenance).