### PR TITLE
Align spec with recent changes

### DIFF
--- a/csp.md
+++ b/csp.md
@@ -5,6 +5,10 @@ This document defines the subset of Content Security Policy (CSP) directives and
 
 The following sections define which directives are allowed and which values are acceptable under the WebCAT policy model.
 
+A single CSP string MUST NOT contain a comma: a comma encodes multiple policies in one header, and the client rejects any `default_csp`/`extra_csp` value containing one.
+
+Where a directive supports both a plain form (e.g. `script-src`, `style-src`) and its `-elem` variant (`script-src-elem`, `style-src-elem`), the same allowed/disallowed values apply to both. The plain directive, when defined, governs its `-elem` counterpart by inheritance; an explicitly defined `-elem` directive MUST independently satisfy the same constraints.
+
 #### 1.1 `default-src`
 
 Allowed values:
@@ -12,8 +16,12 @@ Allowed values:
 * `'none'`
 * `'self'`
 
+When `default-src 'none'` is used to satisfy the "must be none" condition below, `'none'` MUST be its only value.
+
 If `default-src` is not `'none'`, then the manifest MUST also define:
 
+* `script-src`
+* `style-src`
 * `object-src: 'none'`
 * `worker-src`
 * and either `child-src` or `frame-src`
@@ -25,12 +33,15 @@ Allowed values:
 * `'none'`
 * `'self'`
 * `'wasm-unsafe-eval'`
+* `'sha256-...'` (and `'sha384-...'` / `'sha512-...'`) — the hash of an allowed inline script
 
 Not allowed:
 
-* `sha256-...`, `nonce-...`, or `unsafe-eval`
+* `nonce-...`, `'unsafe-eval'`, `'unsafe-inline'`
 
-> **Note**: The use of hash-based or nonce-based script sources is disallowed due to interference with WebAssembly runtime instrumentation and deterministic script analysis.
+> *Note*: Nonce-based sources and `'unsafe-eval'`/`'unsafe-inline'`/`'strict-dynamic'` remain disallowed: nonces are per-response and cannot be verified statically, and the others defeat deterministic script analysis.
+
+The same allowed and disallowed values apply to `script-src-elem`. A defined `script-src` governs `script-src-elem` by inheritance; if a separate `script-src-elem` is present, it MUST satisfy the same constraints.
 
 #### 1.3 `style-src`
 
@@ -38,9 +49,12 @@ Allowed values:
 
 * `'none'`
 * `'self'`
-* `sha256-...`
+* `sha256-...` (and `sha384-...` / `sha512-...`)
 * `'unsafe-inline'`
 * `'unsafe-hashes'`
+* External URLs only if they point to domains that are also enrolled in WEBCAT
+
+The same values apply to `style-src-elem`.
 
 > **Note**: While `'unsafe-inline'` and `'unsafe-hashes'` are currently permitted due to wide usage, they are discouraged for new applications and may be deprecated in future versions of the specification.
 

--- a/manifest.md
+++ b/manifest.md
@@ -29,19 +29,19 @@ This object describes the application metadata, CSP rules, required file hashes,
   The global Content-Security-Policy to enforce for all paths not covered by `extra_csp`.
 
 * `files` (object)
-  Map of relative paths to SHA-256 hashes (base64url).
+  Map of absolute paths to SHA-256 hashes (base64url). Every key begins with `/` (e.g. `"/index.html"`, `"/js/app.js"`).
 
 * `default_index` (string)
-  Path within `files` that resolves the root (`/`).
+  Relative filename appended to a directory request path to resolve it. A request for `/` resolves to `files["/" + default_index]`, and a request for `/dir/` resolves to `files["/dir/" + default_index]`.
 
   Example:
 
   ```json
-  "default_index": "/index.html"
+  "default_index": "index.html"
   ```
 
 * `default_fallback` (string)
-  Path within `files` to serve for non-existent `main_frame` paths. Can be used for SPA catch-alls, rewrites, custom error pages.
+  Absolute path (WITH leading slash) within `files`, served for non-existent `main_frame` paths. Can be used for SPA catch-alls, rewrites, custom error pages. Note the asymmetry with `default_index`: `default_fallback` is a full `files` key, while `default_index` is a bare filename.
 
   Example:
 
@@ -49,8 +49,13 @@ This object describes the application metadata, CSP rules, required file hashes,
   "default_fallback": "/404.html"
   ```
 
-* `timestamp` (string)
-  A Sigsum tree head satisfying the Sigsum policy specified during enrollment, in ASCII text format with escaped newlines (`\\n`).
+* `wasm` (array of strings)
+  List of SHA-256 hashes (base64url) of WebAssembly binaries. The field MUST be present but MAY be an empty array (`[]`) when the application ships no WebAssembly.
+
+### Conditionally required fields
+
+* `timestamp` (string) — REQUIRED for Sigsum manifests, omitted for Sigstore manifests.
+  A Sigsum cosigned tree head satisfying the Sigsum policy specified during enrollment, in ASCII text format with escaped newlines (`\\n`). For Sigstore manifests, freshness is derived from the signing certificate's issuance time instead (see [Server](server.md) `max_age`).
 
   Example:
 
@@ -59,9 +64,6 @@ This object describes the application metadata, CSP rules, required file hashes,
   ```
 
 ### Optional fields
-
-* `wasm` (array of strings)
-  List of SHA-256 hashes (base64url) of WebAssembly binaries.
 
 * `extra_csp` (object)
   Map of path prefixes to CSP strings. Longest‐prefix matching applies.
@@ -77,11 +79,11 @@ This object describes the application metadata, CSP rules, required file hashes,
 
 ## 1.2 `signatures` object
 
-Maps Ed25519 public keys to Sigsum proofs. Each key is an Ed25519 public key encoded as base64url.
+The shape of `signatures` depends on the enrollment type.
 
-### Value format
+### Sigsum: object of proofs
 
-Each value is a Sigsum proof, in ASCII text with escaped newlines.
+For Sigsum enrollments, `signatures` is an object mapping Ed25519 public keys (base64url) to Sigsum proofs. Each value is a Sigsum proof, in ASCII text with escaped newlines.
 
 Example:
 
@@ -91,8 +93,21 @@ Example:
 }
 ```
 
+### Sigstore: array of bundles
+
+For Sigstore enrollments, `signatures` is an array of Sigstore bundles (the serialized `@sigstore/bundle` form, either a message-signature or DSSE bundle):
+
+```json
+"signatures": [
+  { "mediaType": "application/vnd.dev.sigstore.bundle...", "verificationMaterial": { ... }, "messageSignature": { ... } }
+]
+```
+
+A manifest carries one form or the other, never both, matching its enrollment type.
+
 ### Validation rules
 
-* The manifest must contain at least `threshold` valid signature and proofs.
+* For Sigsum, the manifest must contain at least `threshold` valid signatures and proofs; extra or invalid entries are ignored as long as the threshold of valid ones is met.
+* For Sigstore, the manifest verifies if at least one bundle satisfies the enrollment `claims` and certificate freshness.
 * Signatures are verified over the canonicalized `manifest` object.
 * Each proof must satisfy the enrollment policy.

--- a/server.md
+++ b/server.md
@@ -42,7 +42,7 @@ This endpoint MUST return a JSON object with the following structure:
   A base64-encoded string representing the compiled Sigsum policy. This includes the list of witnesses, group definitions, and quorum requirements. See [Sigsum Policy Format](#sigsum-policy-format) for details.
 
 - `max_age`:
-  An integer representing the maximum number of seconds a manifest may remain valid after its signing timestamp. Since different signatures might have different inclusion times, `max_age` is always counted from the oldest one. The timestamp is verified against the CometBFT chain's AppHash as described in the enrollment specification.
+  An integer representing the maximum number of seconds a manifest may remain valid after its witnessed timestamp. The manifest's `timestamp` is a Sigsum cosigned tree head (see [Manifest](manifest.md)); the client verifies it against the trust `policy` — the tree head must be signed by a log key in the policy and cosigned by a witness quorum — and derives the reference time as the median of the verified witness cosignature timestamps. Freshness is then evaluated as `now - median_timestamp > max_age`.
 
 - `cas_url`:
   The base URL of the Content Addressable Storage (CAS) which will be used to verify artifact availability.
@@ -52,7 +52,7 @@ This endpoint MUST return a JSON object with the following structure:
     - all immutable resources referenced inside the manifest (e.g., WASM binaries, HTML, JS, CSS, auxiliary files).
 
 - `logs`:
-  A mapping of Sigsum log public keys (base64url-encoded) to their corresponding log URLs. The enrollment generator includes this mapping, based on the Sigsum trust policy, to help clients locate logs for the purpose of monitoring and auditing.
+  A mapping of Sigsum log public keys (base64url-encoded) to their corresponding log URLs. The enrollment generator includes this mapping, based on the Sigsum trust policy, to help clients locate logs for the purpose of monitoring and auditing. This field is REQUIRED and MUST contain at least one entry; clients reject a Sigsum enrollment whose `logs` map is missing or empty.
 
 #### 1.2 Field Definitions (Sigstore)
 
@@ -82,7 +82,12 @@ Sigstore enrollments use the following structure:
   Each entry represents a constraint that MUST be satisfied by the signing certificate. All claim conditions are evaluated as a logical **AND**. If any claim fails to match, verification fails. OIDs correspond to X.509 certificate extensions. For example:
 
   * `"2.5.29.17"` — Subject Alternative Name (SAN).
-    This matches any SAN entry (e.g., `rfc822Name`, `URI`, or Fulcio `otherName`) whose value exactly equals the expected string.
+    This matches any SAN entry (e.g., `rfc822Name`, `URI`, or Fulcio `otherName`) that satisfies the expected value per the matching rule below.
+
+  Expected values are matched against the certificate as follows, and the same rule applies to both SAN entries and generic extension values:
+
+  * Exact match (default): the certificate value MUST equal the expected string exactly.
+  * Prefix match: if the expected string begins with a caret (`^`), the leading `^` is stripped and the certificate value MUST start with the remaining string. For example `"^https://github.com/example/"` matches any identity under that path.
 
   * `"1.3.6.1.4.1.57264.1.8"` — Fulcio OIDC Issuer (V2).
 
@@ -96,6 +101,44 @@ Sigstore enrollments use the following structure:
 * `max_age`
   An integer representing the maximum number of seconds a manifest may remain valid after its certificate issuance timestamp.
 
+The `type` field is REQUIRED on every enrollment object; clients reject an enrollment that omits it or carries an unrecognized value.
+
+#### 1.3 Browser-facing bundle
+
+While `enrollment.json` is the artifact observed by oracles and committed to the enrollment chain, browsers fetch a bundle that packages the enrollment together with the signed manifest, served at:
+
+```
+https://<domain>/.well-known/webcat/bundle.json
+```
+
+The bundle is a JSON object:
+
+```json
+{
+  "enrollment": { ... },   // identical to the enrolled enrollment.json
+  "manifest":   { ... },   // the `manifest` object (see manifest.md)
+  "signatures": ...         // the `signatures` value (see manifest.md)
+}
+```
+
+The `enrollment` member MUST canonicalize to exactly the bytes that were enrolled, so that its hash matches the canonical hash committed on-chain; otherwise the client rejects the origin. During a policy transition the previous bundle SHOULD additionally be served at `/.well-known/webcat/bundle-prev.json` (see §2), and clients fall back to it when the current bundle's enrollment does not match the committed hash.
+
+As an optimization, a server MAY instead deliver the enrollment inline on the main document response via the header:
+
+```
+x-webcat-enrollment: <base64url-encoded enrollment JSON>
+```
+
+When present, the client uses this value in place of fetching the bundle's enrollment, which removes the blocking background fetch from the verification path. The supplied enrollment is still subject to the same canonical-hash check against the committed state.
+
+#### 1.4 Response Header Constraints
+
+To keep the served resources unambiguously matchable against the manifest, the client enforces the following on responses for enrolled origins:
+
+- `content-security-policy` MUST be present on document responses and MUST NOT appear more than once.
+- The `refresh` and `link` headers are rejected outright (they provide alternative navigation/preload paths that bypass manifest matching).
+- The `location` header is permitted only on main-frame / sub-frame navigations and only as a relative redirect (a path beginning with `/`, `./`, or `../`, never a scheme-relative `//`, absolute URL, or one containing `\`).
+
 ### 2. Policy Transition Mechanism
 
 To transition from one enrollment policy to another, servers MUST follow a strict protocol to ensure uninterrupted verification across all clients.
@@ -104,11 +147,19 @@ To transition from one enrollment policy to another, servers MUST follow a stric
 
 When initiating a policy change:
 
-- The new policy MUST be served persistently at `/.well-known/webcat/enrollment.json`.
-- The previous policy SHOULD be served at `/.well-known/webcat/enrollment-prev.json`.
+- The new policy MUST be served persistently at `/.well-known/webcat/enrollment.json` (and, for browsers, embedded in `/.well-known/webcat/bundle.json`).
+- The previous policy SHOULD be served at `/.well-known/webcat/enrollment-prev.json`, with its corresponding bundle at `/.well-known/webcat/bundle-prev.json`.
 - The values of the two files MUST differ.
 
-TODO: describe here or in client validation how to signal a refresh for the client.
+##### Signaling a refresh
+
+A server signals that a client should re-fetch and re-verify before honoring cached content by setting, on the main document response:
+
+```
+x-webcat-version: <application version>
+```
+
+When the advertised version is newer (semver comparison) than the `version` in the client's cached manifest, the client purges its cached origin state and browser caches for the origin and reloads, picking up the new bundle.
 
 #### 2.2 Enrollment Observation Period
 


### PR DESCRIPTION
This PR aligns the SPEC with a few changes we have done in the past months:
 - Allow for Sigstore prefix matching
 - Clarify update and manifest refresh signaling to clients (`x-webcat-version`)
 - Clarify client bundle fetching and transition behavior
 - Clarify Sigsroe signatures array
 - Update CSP policies to support `sha-xxx` values
 